### PR TITLE
Adding udpate ECS container agent suggestion to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A [Jenkins](https://jenkins-ci.org) slave using JNLP to establish connection.
 
 See [Jenkins Distributed builds](https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds) for more info.
 
+Make sure your ECS container agent is [updated](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-update.html) before running. Older versions do not properly handle the entryPoint parameter. See the [entryPoint](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions) definition for more information.
+
 ## Running
 
 To run a Docker container


### PR DESCRIPTION
Hopefully this will prevent others from wasting time trying to debug why their containerized jobs are not launching. The ECS cluster I created was running version 1.4.0 of the container agent by default, which does not work with the ```ENTRYPOINT``` parameter in the Dockerfile.