### PR TITLE
Upgrade remoting to 2.60

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ MAINTAINER Nicolas De Loof <nicolas.deloof@gmail.com>
 ENV HOME /home/jenkins
 RUN useradd -c "Jenkins user" -d $HOME -m jenkins
 
-RUN curl --create-dirs -sSLo /usr/share/jenkins/slave.jar http://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/2.52/remoting-2.52.jar \
+RUN curl --create-dirs -sSLo /usr/share/jenkins/slave.jar http://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/2.60/remoting-2.60.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/slave.jar
 


### PR DESCRIPTION
This fix upgrades remoting to 2.60, which is the latest version.

There are much changes since 2.52. The major ones are:
* Support of the JNLP3 protocol with encryption
* Memory leak fixes
* Fixes for several connectivity issues

Incomplete changelog is available here: https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md

@reviewbybees @jenkinsci/code-reviewers