### PR TITLE
Upgrade remoting to 2.62 and disable JNLP3 protocol by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ MAINTAINER Nicolas De Loof <nicolas.deloof@gmail.com>
 ENV HOME /home/jenkins
 RUN useradd -c "Jenkins user" -d $HOME -m jenkins
 
-ARG VERSION=2.60
+ARG VERSION=2.62
 
 RUN curl --create-dirs -sSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Make sure your ECS container agent is [updated](http://docs.aws.amazon.com/Amazo
 
 ## Configuration specifics
 
-By default, JnlpProtocol3 is disabled due to the known issues in this protocol implementation.
-You can enable this protocol on your own risk using the <code>JNLP_PROTOCOL_OPTS</code> property.
+By default, JnlpProtocol3 is disabled due to the known stability and scalability issues.
+You can enable this protocol on your own risk using the 
+<code>JNLP_PROTOCOL_OPTS=-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=false</code> property.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ See [Jenkins Distributed builds](https://wiki.jenkins-ci.org/display/JENKINS/Dis
 
 Make sure your ECS container agent is [updated](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-update.html) before running. Older versions do not properly handle the entryPoint parameter. See the [entryPoint](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions) definition for more information.
 
+## Configuration specifics
+
+By default, JnlpProtocol3 is disabled due to the known issues in this protocol implementation.
+You can enable this protocol on your own risk using the <code>JNLP_PROTOCOL_OPTS</code> property.
+
 ## Running
 
 To run a Docker container

--- a/jenkins-slave
+++ b/jenkins-slave
@@ -45,5 +45,10 @@ else
 		URL="-url $JENKINS_URL"
 	fi
 
-	exec java $JAVA_OPTS -cp /usr/share/jenkins/slave.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL "$@"
+	if [ ! -z "$JNLP_PROTOCOL_OPTS" ]; then
+		echo "Warning: JnlpProtocol3 is disabled by defaulr, use JNLP_PROTOCOL_OPTS to alter the behavior"
+		JNLP_PROTOCOL_OPTS="-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
+	fi
+
+	exec java $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/slave.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL "$@"
 fi

--- a/jenkins-slave
+++ b/jenkins-slave
@@ -46,7 +46,7 @@ else
 	fi
 
 	if [ ! -z "$JNLP_PROTOCOL_OPTS" ]; then
-		echo "Warning: JnlpProtocol3 is disabled by defaulr, use JNLP_PROTOCOL_OPTS to alter the behavior"
+		echo "Warning: JnlpProtocol3 is disabled by default, use JNLP_PROTOCOL_OPTS to alter the behavior"
 		JNLP_PROTOCOL_OPTS="-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
 	fi
 

--- a/jenkins-slave
+++ b/jenkins-slave
@@ -45,7 +45,7 @@ else
 		URL="-url $JENKINS_URL"
 	fi
 
-	if [ ! -z "$JNLP_PROTOCOL_OPTS" ]; then
+	if [ -z "$JNLP_PROTOCOL_OPTS" ]; then
 		echo "Warning: JnlpProtocol3 is disabled by default, use JNLP_PROTOCOL_OPTS to alter the behavior"
 		JNLP_PROTOCOL_OPTS="-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
 	fi


### PR DESCRIPTION
It's a follow-up to the discussion in #8 

@reviewbybees (esp @carlossg and @daniel-beck )