### PR TITLE
Agent name backwards compatabiltiy 

### DIFF
--- a/jenkins-slave
+++ b/jenkins-slave
@@ -47,6 +47,10 @@ else
 		URL="-url $JENKINS_URL"
 	fi
 
+	if [ -n "$JENKINS_NAME" ]; then
+		JENKINS_AGENT_NAME="-url $JENKINS_NAME"
+	fi	
+
 	if [ -z "$JNLP_PROTOCOL_OPTS" ]; then
 		echo "Warning: JnlpProtocol3 is disabled by default, use JNLP_PROTOCOL_OPTS to alter the behavior"
 		JNLP_PROTOCOL_OPTS="-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"

--- a/jenkins-slave
+++ b/jenkins-slave
@@ -48,7 +48,7 @@ else
 	fi
 
 	if [ -n "$JENKINS_NAME" ]; then
-		JENKINS_AGENT_NAME="-url $JENKINS_NAME"
+		JENKINS_AGENT_NAME="$JENKINS_NAME"
 	fi	
 
 	if [ -z "$JNLP_PROTOCOL_OPTS" ]; then


### PR DESCRIPTION
The jenkins name change here: https://github.com/jenkinsci/docker-jnlp-slave/commit/96c1c94 was a breaking change for me when I upgraded my Jenkins cluster. 

Make this commit backwards compatabile. @carlossg 