### PR TITLE
Agent name backwards compatibility (#28)

### DIFF
--- a/jenkins-slave
+++ b/jenkins-slave
@@ -47,6 +47,10 @@ else
 		URL="-url $JENKINS_URL"
 	fi
 
+	if [ -n "$JENKINS_NAME" ]; then
+		JENKINS_AGENT_NAME="$JENKINS_NAME"
+	fi	
+
 	if [ -z "$JNLP_PROTOCOL_OPTS" ]; then
 		echo "Warning: JnlpProtocol3 is disabled by default, use JNLP_PROTOCOL_OPTS to alter the behavior"
 		JNLP_PROTOCOL_OPTS="-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"


### PR DESCRIPTION
Applies the fix from #28 to the Alpine branch