### PR TITLE
Add JENKINS_AGENT_WORKDIR env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Optional environment variables:
 * `JENKINS_TUNNEL`: (`HOST:PORT`) connect to this agent host and port instead of Jenkins server, assuming this one do route TCP traffic to Jenkins master. Useful when when Jenkins runs behind a load balancer, reverse proxy, etc.
 * `JENKINS_SECRET`: agent secret, if not set as an argument
 * `JENKINS_AGENT_NAME`: agent name, if not set as an argument
+* `JENKINS_AGENT_WORKDIR`: agent work directory, if not set by optional parameter `-workDir`
 
 ## Configuration specifics
 

--- a/jenkins-slave
+++ b/jenkins-slave
@@ -28,6 +28,7 @@
 # * JENKINS_URL : alternate jenkins URL
 # * JENKINS_SECRET : agent secret, if not set as an argument
 # * JENKINS_AGENT_NAME : agent name, if not set as an argument
+# * JENKINS_AGENT_WORKDIR : agent work directory, if not set as an argument
 
 if [ $# -eq 1 ]; then
 
@@ -40,6 +41,13 @@ else
 	if [[ "$@" != *"-tunnel "* ]]; then
 		if [ ! -z "$JENKINS_TUNNEL" ]; then
 			TUNNEL="-tunnel $JENKINS_TUNNEL"
+		fi
+	fi
+
+	# if -workDir is not provided try env vars
+	if [[ "$@" != *"-workDir "* ]]; then
+		if [ ! -z "$JENKINS_AGENT_WORKDIR" ]; then
+			WORKDIR="-workDir $JENKINS_AGENT_WORKDIR"
 		fi
 	fi
 
@@ -78,5 +86,5 @@ else
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
 
-	exec java $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/slave.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
+	exec java $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/slave.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
 fi

--- a/jenkins-slave
+++ b/jenkins-slave
@@ -28,7 +28,7 @@
 # * JENKINS_URL : alternate jenkins URL
 # * JENKINS_SECRET : agent secret, if not set as an argument
 # * JENKINS_AGENT_NAME : agent name, if not set as an argument
-# * JENKINS_AGENT_WORKDIR : agent work directory, if not set as an argument
+# * JENKINS_AGENT_WORKDIR : agent work directory, if not set by optional parameter -workDir
 
 if [ $# -eq 1 ]; then
 


### PR DESCRIPTION
I added the possibility to specify the agent workdir through env variable, as an alternative to specify the `-workDir` parameter into the Docker `command` directive.

This change was needed in order to be able to use [work directories](https://github.com/jenkinsci/remoting/blob/master/docs/workDir.md) with the agents created by the [Jenkins ECS plugin](https://wiki.jenkins.io/display/JENKINS/Amazon+EC2+Container+Service+Plugin) and avoid to change the plugin itself, as [new pull requests have not being merged since a long time](https://github.com/jenkinsci/amazon-ecs-plugin/pulls?q=is%3Apr+is%3Aclosed).

The issue with that plugin is the fact that you can't change the `command` parameter in slaves' task definitions.

