### PR TITLE
Update Remoting to 3.15 + fix documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The MIT License
 #
-#  Copyright (c) 2015, CloudBees, Inc.
+#  Copyright (c) 2015-2017, CloudBees, Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -20,8 +20,9 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM jenkinsci/slave
-MAINTAINER Nicolas De Loof <nicolas.deloof@gmail.com>
+FROM jenkins/slave:3.15-1
+MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
+LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols" Vendor="Jenkins project" Version="3.15"
 
 COPY jenkins-slave /usr/local/bin/jenkins-slave
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Jenkins JNLP Agent Docker image
 
-[![Docker Stars](https://img.shields.io/docker/stars/jenkinsci/jnlp-slave.svg)](https://hub.docker.com/r/jenkinsci/jnlp-slave/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/jenkinsci/jnlp-slave.svg)](https://hub.docker.com/r/jenkinsci/jnlp-slave/)
-[![Docker Automated build](https://img.shields.io/docker/automated/jenkinsci/jnlp-slave.svg)](https://hub.docker.com/r/jenkinsci/jnlp-slave/)
+[![Docker Stars](https://img.shields.io/docker/stars/jenkins/jnlp-slave.svg)](https://hub.docker.com/r/jenkins/jnlp-slave/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/jenkins/jnlp-slave.svg)](https://hub.docker.com/r/jenkins/jnlp-slave/)
+[![Docker Automated build](https://img.shields.io/docker/automated/jenkins/jnlp-slave.svg)](https://hub.docker.com/r/jenkins/jnlp-slave/)
+
+:exclamation: **Warning!** This image used to be published as [jenkinsci/jnlp-slave/](https://hub.docker.com/r/jenkinsci/jnlp-slave/). 
+This release destination is deprecated.
 
 This is an image for [Jenkins](https://jenkins.io) agent (FKA "slave") using JNLP to establish connection.
 This agent is powered by the [Jenkins Remoting library](https://github.com/jenkinsci/remoting), which version is being taken from the base [Docker Agent](https://github.com/jenkinsci/docker-slave/) image.


### PR DESCRIPTION
- [x] Update the base image and make the version explicit
- [x] Update documentation to finalize https://github.com/jenkinsci/docker-jnlp-slave/commit/08ce90f9b9c3962be9b68236e63339589abbb281 from @carlossg 

@reviewbybees @carlossg @rysteboe
