### PR TITLE
if java home is defined, use it

### DIFF
--- a/jenkins-slave
+++ b/jenkins-slave
@@ -37,7 +37,7 @@ if [ $# -eq 1 ]; then
 
 else
 
-	# if -tunnel is not provided try env vars
+	# if -tunnel is not provided, try env vars
 	case "$@" in
 		*"-tunnel "*) ;;
 		*)
@@ -46,7 +46,7 @@ else
 		fi ;;
 	esac
 
-	# if -workDir is not provided try env vars
+	# if -workDir is not provided, try env vars
 	if [ ! -z "$JENKINS_AGENT_WORKDIR" ]; then
 		case "$@" in
 			*"-workDir"*) echo "Warning: Work directory is defined twice in command-line arguments and the environment variable" ;;
@@ -67,8 +67,14 @@ else
 		echo "Warning: JnlpProtocol3 is disabled by default, use JNLP_PROTOCOL_OPTS to alter the behavior"
 		JNLP_PROTOCOL_OPTS="-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
 	fi
+	
+	# if java home is defined, use it
+	JAVA_BIN="java"
+	if [ "$JAVA_HOME" ]; then
+		JAVA_BIN="$JAVA_HOME/bin/java"
+	fi
 
-	# If both required options are defined, do not pass the parameters
+	# if both required options are defined, do not pass the parameters
 	OPT_JENKINS_SECRET=""
 	if [ -n "$JENKINS_SECRET" ]; then
 		case "$@" in
@@ -90,5 +96,5 @@ else
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
 
-	exec java $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/slave.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
+	exec $JAVA_BIN $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/slave.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
 fi


### PR DESCRIPTION
When I run the slave I want the java home environment variable to be honored and therefore used.