### PR TITLE
[JENKINS-51986] Add JDK-11 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM jenkins/slave:3.27-1
+FROM jenkins/slave:3.27-1-jdk11
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols" Vendor="Jenkins project" Version="3.27"
 


### PR DESCRIPTION
[JENKINS-51986](https://issues.jenkins-ci.org/browse/JENKINS-51986)

The Automated build already got configured by @oleg-nenashev earlier today on https://hub.docker.com/r/jenkins/jnlp-slave/tags/

The `latest-jdk11` is tracking the `jdk11` branch of https://github.com/jenkinsci/docker-jnlp-slave for automated build.

@jenkinsci/java11-support for review.