### PR TITLE
Use jenkins/slave:latest-jdk11 as base for jenkins/jnlp-slave:latest-jdk11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM jenkins/slave:3.27-1-jdk11
+FROM jenkins/slave:latest-jdk11
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols" Vendor="Jenkins project" Version="3.27"
 


### PR DESCRIPTION
fixes #77 for "latest-jdk11"