### PR TITLE
Update the base image to the latest version and pin the release. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,9 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM jenkins/slave:latest
+FROM jenkins/slave:3.29-2
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
-LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols" Vendor="Jenkins project" Version="3.27"
+LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols" Vendor="Jenkins project" Version="3.29"
 
 COPY jenkins-slave /usr/local/bin/jenkins-slave
 


### PR DESCRIPTION
Integrates https://github.com/jenkinsci/docker-slave/issues/60

I also pinned the version of the parent image, because my plan is to enable Dependabot in this repo

