### PR TITLE
Add the executable flag to `jenkins-agent` binary (regression in 3.25-3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ ARG user=jenkins
 
 USER root
 COPY jenkins-agent /usr/local/bin/jenkins-agent
-RUN ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
+RUN chmod +x /usr/local/bin/jenkins-agent &&\
+    ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
 USER ${user}
 
 ENTRYPOINT ["jenkins-agent"]

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -28,7 +28,8 @@ ARG user=jenkins
 
 USER root
 COPY jenkins-agent /usr/local/bin/jenkins-agent
-RUN ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
+RUN chmod +x /usr/local/bin/jenkins-agent &&\
+    ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
 USER ${user}
 
 ENTRYPOINT ["jenkins-slave"]

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -28,7 +28,8 @@ ARG user=jenkins
 
 USER root
 COPY jenkins-agent /usr/local/bin/jenkins-agent
-RUN ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
+RUN chmod +x /usr/local/bin/jenkins-agent &&\
+    ln -s /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-slave
 USER ${user}
 
 ENTRYPOINT ["jenkins-slave"]


### PR DESCRIPTION
Latest pushed images to the docker registry are broken:
```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:345: starting container process caused "exec: \"jenkins-slave\": executable file not found in $PATH": unknown.
```