### PR TITLE
Adjusted jenkins-agent script for direct connection (+ FROM jenkins/slave:3.35-3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM jenkins/slave:3.35-2
+FROM jenkins/slave:3.35-3
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols" Vendor="Jenkins project" Version="3.35-2"
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM jenkins/slave:3.35-2-alpine
+FROM jenkins/slave:3.35-3-alpine
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols" Vendor="Jenkins project" Version="3.35-2"
 

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM jenkins/slave:3.35-2-jdk11
+FROM jenkins/slave:3.35-3-jdk11
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 LABEL Description="This is a base image, which allows connecting Jenkins agents via JNLP protocols" Vendor="Jenkins project" Version="3.35-2"
 

--- a/jenkins-agent
+++ b/jenkins-agent
@@ -29,6 +29,11 @@
 # * JENKINS_SECRET : agent secret, if not set as an argument
 # * JENKINS_AGENT_NAME : agent name, if not set as an argument
 # * JENKINS_AGENT_WORKDIR : agent work directory, if not set by optional parameter -workDir
+# * JENKINS_DIRECT_CONNECTION: Connect directly to this TCP agent port, skipping the HTTP(S) connection parameter download.
+#                              Value: "<HOST>:<PORT>"
+# * JENKINS_INSTANCE_IDENTITY: The base64 encoded InstanceIdentity byte array of the Jenkins master. When this is set,
+#                              the agent skips connecting to an HTTP(S) port for connection info.
+# * JENKINS_PROTOCOLS:         Specify the remoting protocols to attempt when instanceIdentity is provided.
 
 if [ $# -eq 1 ]; then
 
@@ -61,13 +66,25 @@ else
 
 	if [ -n "$JENKINS_NAME" ]; then
 		JENKINS_AGENT_NAME="$JENKINS_NAME"
-	fi  
+	fi
 
 	if [ -z "$JNLP_PROTOCOL_OPTS" ]; then
 		echo "Warning: JnlpProtocol3 is disabled by default, use JNLP_PROTOCOL_OPTS to alter the behavior"
 		JNLP_PROTOCOL_OPTS="-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
 	fi
-	
+
+	if [ -n "$JENKINS_PROTOCOLS" ]; then
+		PROTOCOLS="-protocols $JENKINS_PROTOCOLS"
+	fi
+
+	if [ -n "$JENKINS_DIRECT_CONNECTION" ]; then
+		DIRECT="-direct $JENKINS_DIRECT_CONNECTION"
+	fi
+
+	if [ -n "$JENKINS_INSTANCE_IDENTITY" ]; then
+		INSTANCE_IDENTITY="-instanceIdentity $JENKINS_INSTANCE_IDENTITY"
+	fi
+
 	# if java home is defined, use it
 	JAVA_BIN="java"
 	if [ "$JAVA_HOME" ]; then
@@ -96,5 +113,5 @@ else
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
 
-	exec $JAVA_BIN $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
+	exec $JAVA_BIN $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
 fi


### PR DESCRIPTION
[Remoting#3.34](https://github.com/jenkinsci/remoting/releases/tag/remoting-3.34) introduced [direct inbound TCP agent connections](https://github.com/jenkinsci/remoting/pull/338) (to masters without Web UI/HTTP port). The [feature is documented here](https://github.com/jenkinsci/remoting/blob/master/docs/tcpAgent.md#connect-directly-to-tcp-port).

This Pull Request adds the required parameters to the `jenkins-agent` script. In particular this change is needed to enable the [Kubernetes plugin](https://github.com/jenkinsci/kubernetes-plugin) to make use of this feature, e.g. in combination with [Jenkinsfile Runner](https://github.com/jenkinsci/jenkinsfile-runner) on Kubernetes (without HTTP port).