### PR TITLE
Update to Remoting 3.40.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG version=3.36-1
+ARG version=3.40-1
 FROM jenkins/slave:$version
 
 ARG version

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG version=3.36-1-alpine
+ARG version=3.40-1-alpine
 FROM jenkins/slave:$version
 
 ARG version

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG version=3.36-1-jdk11
+ARG version=3.40-1-jdk11
 FROM jenkins/slave:$version
 
 ARG version

--- a/README.md
+++ b/README.md
@@ -48,10 +48,6 @@ Optional environment variables:
 
 ### Enabled JNLP protocols
 
-By default, the [JNLP3-connect](https://github.com/jenkinsci/remoting/blob/master/docs/protocols.md#jnlp3-connect) is disabled due to the known stability and scalability issues.
-You can enable this protocol at your own risk using the 
-`JNLP_PROTOCOL_OPTS=-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=false` property (the protocol should be enabled on the master side as well).
-
 In Jenkins versions starting from `2.27` there is a [JNLP4-connect](https://github.com/jenkinsci/remoting/blob/master/docs/protocols.md#jnlp4-connect) protocol. 
 If you use Jenkins `2.32.x LTS`, it is recommended to enable the protocol on your instance.
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Optional environment variables:
 
 ### Enabled JNLP protocols
 
-In Jenkins versions starting from `2.27` there is a [JNLP4-connect](https://github.com/jenkinsci/remoting/blob/master/docs/protocols.md#jnlp4-connect) protocol. 
-If you use Jenkins `2.32.x LTS`, it is recommended to enable the protocol on your instance.
+As of version 3.40-1 this image only supports the [JNLP4-connect](https://github.com/jenkinsci/remoting/blob/master/docs/protocols.md#jnlp4-connect) protocol.
+Earlier, long-unsupported protocols have been removed.
+As a result, Jenkins versions prior to 2.32 are no longer supported.
 
 ### Amazon ECS
 

--- a/jenkins-agent
+++ b/jenkins-agent
@@ -2,7 +2,7 @@
 
 # The MIT License
 #
-#  Copyright (c) 2015-2019, CloudBees, Inc.
+#  Copyright (c) 2015-2020, CloudBees, Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -68,11 +68,6 @@ else
 		JENKINS_AGENT_NAME="$JENKINS_NAME"
 	fi
 
-	if [ -z "$JNLP_PROTOCOL_OPTS" ]; then
-		echo "Warning: JnlpProtocol3 is disabled by default, use JNLP_PROTOCOL_OPTS to alter the behavior"
-		JNLP_PROTOCOL_OPTS="-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
-	fi
-
 	if [ -n "$JENKINS_PROTOCOLS" ]; then
 		PROTOCOLS="-protocols $JENKINS_PROTOCOLS"
 	fi
@@ -113,5 +108,5 @@ else
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
 
-	exec $JAVA_BIN $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
+	exec $JAVA_BIN $JAVA_OPTS -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
 fi

--- a/jenkins-agent.ps1
+++ b/jenkins-agent.ps1
@@ -1,6 +1,6 @@
 # The MIT License
 #
-#  Copyright (c) 2020, Alex Earl
+#  Copyright (c) 2019-2020, Alex Earl
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal

--- a/jenkins-agent.ps1
+++ b/jenkins-agent.ps1
@@ -1,6 +1,6 @@
 # The MIT License
 #
-#  Copyright (c) 2019, Alex Earl
+#  Copyright (c) 2020, Alex Earl
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -88,12 +88,6 @@ if(![System.String]::IsNullOrWhiteSpace($Cmd)) {
 	}
 	$Name = $Name.Trim()
 
-	$jnlpProtocolOpts = ''
-	if([System.String]::IsNullOrWhiteSpace($env:JNLP_PROTOCOL_OPTS)) {
-		Write-Warning "JnlpProtocol3 is disabled by default, use JNLP_PROTOCOL_OPTS to alter the behavior"
-		$jnlpProtocolOpts="-D`"org.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true`""
-	}
-
 	# if java home is defined, use it
 	$JAVA_BIN="java.exe"
 	if(![System.String]::IsNullOrWhiteSpace($JavaHome)) {
@@ -114,5 +108,5 @@ if(![System.String]::IsNullOrWhiteSpace($Cmd)) {
 
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
-	Start-Process -FilePath $JAVA_BIN -Wait -NoNewWindow -ArgumentList $("$jnlpProtocolOpts -cp C:/ProgramData/Jenkins/agent.jar hudson.remoting.jnlp.Main -headless$Tunnel$Url$WorkDir$Secret $Name")
+	Start-Process -FilePath $JAVA_BIN -Wait -NoNewWindow -ArgumentList $("-cp C:/ProgramData/Jenkins/agent.jar hudson.remoting.jnlp.Main -headless$Tunnel$Url$WorkDir$Secret $Name")
 }


### PR DESCRIPTION
This Remoting version removes old, deprecated, unsupported protocols versions 1, 2, and 3. And the unused plain protocol. See the [Remoting changelog](https://github.com/jenkinsci/remoting/releases) for full details.