### PR TITLE
Update to Remoting 4.0. Add WebSockets support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG version=3.40-1
+ARG version=4.0-1
 FROM jenkins/slave:$version
 
 ARG version

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG version=3.40-1-alpine
+ARG version=4.0-1-alpine
 FROM jenkins/slave:$version
 
 ARG version

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG version=3.40-1-jdk11
+ARG version=4.0-1-jdk11
 FROM jenkins/slave:$version
 
 ARG version


### PR DESCRIPTION
This Remoting release adds support for WebSockets. See the [Remoting changelog](https://github.com/jenkinsci/remoting/releases/tag/remoting-4.0) for full details. 