### PR TITLE
[JENKINS-61409] - Upgrade to Remoting version 4.3 for WebSocket large payload fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG version=4.0.1-1
+ARG version=4.3-1
 FROM jenkins/slave:$version
 
 ARG version

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG version=4.0.1-1-alpine
+ARG version=4.3-1-alpine
 FROM jenkins/slave:$version
 
 ARG version

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG version=4.0.1-1-jdk11
+ARG version=4.3-1-jdk11
 FROM jenkins/slave:$version
 
 ARG version


### PR DESCRIPTION
See [JENKINS-61409](https://issues.jenkins-ci.org/browse/JENKINS-61409).

Also see the [Remoting changelog](https://github.com/jenkinsci/remoting/releases/tag/remoting-4.3).

Dependent on jenkinsci/docker-slave#110.